### PR TITLE
Centralize dependency installation to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ This project provides end-to-end flows supporting users of PyTorch that want to 
 Setup the venv for running:
 
 ```
-# Install torch-mlir dependencies:
-# TODO: Make the torch-mlir package automatically install the dependencies.
-(iree-torch.venv) $ python -m pip install -r "${TORCH_MLIR_SRC_ROOT}/requirements.txt"
+# Create a Python virtual environment.
+$ python -m venv iree-torch.venv
+$ source iree-torch.venv/bin/activate
 
 # Option 1: Install Torch-MLIR and IREE from nightly packages:
-(iree-torch.venv) $ python -m pip install iree-compiler iree-runtime -f https://github.com/google/iree/releases
-(iree-torch.venv) $ python -m pip install torch-mlir -f https://github.com/llvm/torch-mlir/releases
+(iree-torch.venv) $ python -m pip install -r "${IREE_TORCH_SRC_ROOT}/requirements.txt"
 
 # Option 2: For development, build from source and set `PYTHONPATH`:
 ninja -C "${TORCH_MLIR_BUILD_ROOT}" TorchMLIRPythonModules
@@ -30,7 +29,7 @@ ninja -C "${IREE_BUILD_ROOT}" IREECompilerPythonModules bindings_python_iree_run
 export PYTHONPATH="${IREE_BUILD_ROOT}/bindings/python:${IREE_BUILD_ROOT}/compiler-api/python_package:${TORCH_MLIR_BUILD_ROOT}/tools/torch-mlir/python_packages/torch_mlir:${PYTHONPATH}"
 ```
 
-Run the Torch-MLIR TorchScript e2e test suite on IREE
+Run the Torch-MLIR TorchScript e2e test suite on IREE:
 ```
 # Run all the tests on the default backend (`dylib`).
 (iree-torch.venv) $ python torchscript_e2e_main.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,18 @@
+# IREE
+-f https://github.com/google/iree/releases
+iree-compiler
+iree-runtime
+
+# Torch-MLIR
+-f https://github.com/llvm/torch-mlir/releases
+torch-mlir
+
+# TODO: This is copied from the torch-mlir requirements.txt
+# Because it requires installing a nightly build of PyTorch,
+# it cannot be installed as a normal dependency of the
+# torch-mlir Python package.
+-f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+--pre
+torch
+torchvision
+numpy


### PR DESCRIPTION
This makes the README instructions simpler.