### PR TITLE
Start factoring some code into a `python/` directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,18 @@ $ source iree-torch.venv/bin/activate
 # Option 2: For development, build from source and set `PYTHONPATH`:
 ninja -C "${TORCH_MLIR_BUILD_ROOT}" TorchMLIRPythonModules
 ninja -C "${IREE_BUILD_ROOT}" IREECompilerPythonModules bindings_python_iree_runtime_runtime
-export PYTHONPATH="${IREE_BUILD_ROOT}/bindings/python:${IREE_BUILD_ROOT}/compiler-api/python_package:${TORCH_MLIR_BUILD_ROOT}/tools/torch-mlir/python_packages/torch_mlir:${PYTHONPATH}"
+export PYTHONPATH="${IREE_BUILD_ROOT}/runtime/bindings/python:${IREE_BUILD_ROOT}/compiler/bindings/python:${TORCH_MLIR_BUILD_ROOT}/tools/torch-mlir/python_packages/torch_mlir:${PYTHONPATH}"
 ```
 
 Run the Torch-MLIR TorchScript e2e test suite on IREE:
 ```
 # Run all the tests on the default backend (`dylib`).
-(iree-torch.venv) $ python torchscript_e2e_main.py
+(iree-torch.venv) $ tools/torchscript_e2e_test.sh
 # Run all tests on the `vmvx` backend.
-(iree-torch.venv) $ python torchscript_e2e_main.py --config vmvx
+(iree-torch.venv) $ tools/torchscript_e2e_test.sh --config vmvx
 # Filter the tests (with a regex) and report failures with verbose error messages.
 # This is good for drilling down on a single test as well.
-(iree-torch.venv) $ python torchscript_e2e_main.py --filter Elementwise --verbose
+(iree-torch.venv) $ tools/torchscript_e2e_test.sh --filter Elementwise --verbose
+# Shorter option names.
+(iree-torch.venv) $ tools/torchscript_e2e_test.sh -f Elementwise -v
 ```

--- a/python/iree_torch/__init__.py
+++ b/python/iree_torch/__init__.py
@@ -1,0 +1,92 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import torch
+from torch.utils._pytree import tree_map
+
+import iree.runtime as ireert
+import iree.compiler as ireec
+
+
+class IREEInvoker:
+    """A wrapper around an IREE module that provides a Pythonic interface.
+    
+    Specifically, this adapts `module.forward(...)` and similar calls into
+    lower-level calls into the functions in the IREE module, and also converts
+    between the IREE and Torch types.
+    """
+
+    def __init__(self, iree_module):
+        self._iree_module = iree_module
+        self.device = iree_module._context.config.device
+
+    def __getattr__(self, function_name: str):
+        def invoke(*args):
+            # TODO: Investigate how to share CUDA arrays between IREE and Torch.
+            iree_args = tree_map(
+                lambda x: ireert.asdevicearray(self.device, x), args)
+            result = self._iree_module[function_name](*iree_args)
+            # TODO: Investigate why a copy is needed here.
+            # Without the copy, certain sets of tests, when run together, will
+            # cause a segfault when the process is exiting.
+            # It seems to be related to Torch attempting to free a Numpy array
+            # that is backed by IREE memory, resulting in
+            # iree_hal_buffer_view_release reading from a null pointer.
+            return tree_map(lambda x: torch.from_numpy(np.asarray(x).copy()),
+                            result)
+        return invoke
+
+
+class NumpyIREEInvoker:
+    """A wrapper around IREEInvoker which accepts and returns numpy types"""
+
+    def __init__(self, iree_invoker):
+        self.iree_invoker = iree_invoker
+
+    def __getattr__(self, function_name: str):
+        def invoke(*args):
+            torch_args = tree_map(lambda x: torch.from_numpy(x), args)
+            result = getattr(self.iree_invoker, function_name)(*torch_args)
+            return tree_map(lambda x: x.numpy(), result)
+        return invoke
+
+
+def compile_to_vmfb(mlir_module, target_backend="dylib"):
+    """Compile an MLIR module to an IREE Flatbuffer.
+
+    The module is expected to be in the format produced by `torch_mlir.compile`
+    with `OutputType.LINALG_ON_TENSORS`.
+
+    TODO: Expose more compiler options.
+    """
+    # Here, mlir_module is typically going to be coming from the Torch-MLIR
+    # MLIR CAPI assembly. We stringify it to cross the border into the
+    # IREE MLIR CAPI assembly.
+    return ireec.compile_str(str(mlir_module),
+                             target_backends=[target_backend],
+                             input_type=ireec.InputType.TM_TENSOR)
+
+
+def load_vmfb(flatbuffer, driver="dylib"):
+    """Load an IREE Flatbuffer into an in-process runtime wrapper.
+
+    The wrapper accepts and returns `torch.Tensor` types.
+    """
+    vm_module = ireert.VmModule.from_flatbuffer(flatbuffer)
+    config = ireert.Config(driver_name=driver)
+    ctx = ireert.SystemContext(config=config)
+    ctx.add_vm_module(vm_module)
+    return IREEInvoker(ctx.modules.module)

--- a/tools/torchscript_e2e_test.sh
+++ b/tools/torchscript_e2e_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+src_dir="$(realpath $(dirname $0)/..)"
+
+cd "$src_dir"
+
+# Ensure PYTHONPATH is set for export to child processes, even if empty.
+export PYTHONPATH=${PYTHONPATH-}
+export PYTHONPATH="$PYTHONPATH:${src_dir}/python"
+
+python tools/torchscript_e2e_main.py "$@"


### PR DESCRIPTION
This is the minimum skeleton to make things reusable between the e2e
testing and examples. There is still API design work to be done here to
better serve use cases and to provide a more comprehensive experience
(rather than somewhat low-level tools).